### PR TITLE
Speed up toPathPointsFromMatrices by using .push instead of .concat w…

### DIFF
--- a/measure/modules/draw/module.ts
+++ b/measure/modules/draw/module.ts
@@ -451,7 +451,8 @@ function toPathPointsFromMatrices(
             const _p = toScreen(projMat, width, height, p0);
             points2d.push(_p);
             indicesOnScreen.push(currentIdx++);
-            return tail.concat([_p]);
+            tail.push(_p);
+            return tail;
         }
         const _p = toScreen(projMat, width, height, head);
         points2d.push(_p);
@@ -460,10 +461,12 @@ function toPathPointsFromMatrices(
             const _p0 = toScreen(projMat, width, height, p0);
             indicesOnScreen.push(currentIdx);
             indicesOnScreen.push(currentIdx++);
-            return tail.concat([_p0], [_p]);
+            tail.push(_p0, _p);
+            return tail;
         }
         indicesOnScreen.push(currentIdx++);
-        return tail.concat([_p]);
+        tail.push(_p);
+        return tail;
     }, [] as ReadonlyVec2[]);
     if (screenPoints.length) {
         return { screenPoints, points2d, indicesOnScreen };


### PR DESCRIPTION
…hen building screenPoints array

Using `concat` there has no benefits but involves a lot of array copying and GC. On large point arrays (e.g. 300 points) speed up for me is around 40%.

Other things I've tried that didn't give perf benefits:
- Replacing reduce with forEach
- Preallocating arrays to `points.length` (somehow gets slower)
- Moving `clip` outside (just 0.8% percent gain)
- Moving intermediate `map` to build `sv` into `reduce` gives less than 2% gain, so not worth it probably

Reason for optimizing: new feature I'm working on - Arcgis - is using this function (not directly) to render relatively large amount of polygons and polylines and this function call takes a lot of scripting time.