### PR TITLE
Speed up to path points from matrices 2

### DIFF
--- a/measure/modules/draw/module.ts
+++ b/measure/modules/draw/module.ts
@@ -451,7 +451,8 @@ function toPathPointsFromMatrices(
             const _p = toScreen(projMat, width, height, p0);
             points2d.push(_p);
             indicesOnScreen.push(currentIdx++);
-            return tail.concat([_p]);
+            tail.push(_p);
+            return tail;
         }
         const _p = toScreen(projMat, width, height, head);
         points2d.push(_p);
@@ -460,10 +461,12 @@ function toPathPointsFromMatrices(
             const _p0 = toScreen(projMat, width, height, p0);
             indicesOnScreen.push(currentIdx);
             indicesOnScreen.push(currentIdx++);
-            return tail.concat([_p0], [_p]);
+            tail.push(_p0, _p);
+            return tail;
         }
         indicesOnScreen.push(currentIdx++);
-        return tail.concat([_p]);
+        tail.push(_p);
+        return tail;
     }, [] as ReadonlyVec2[]);
     if (screenPoints.length) {
         return { screenPoints, points2d, indicesOnScreen };


### PR DESCRIPTION
(this includes changes of the previous PR #4)

More optimizations for toPathPointsFromMatrices. Turns out vector creation takes a lot of time, so trying to reuse vectors as much as possible (as long as it's still mostly readable).

- In clip reuse `out` vector and use same vector across the function. In both cases `out` is only used in next line `toScreen` calculation, so should be safe
- Remove intermediate `sv` array. Inside the `reduce` we only use current and previous value, so instead introduce `head` and `prevHead`. Reuse vectors
- toScreen: `transformMat4` was creating 2 intermediate local vectors. Instead introduce 2 vectors in outer scope and reuse them. To enforce better scope for these outer vectors function is wrapped into IIFE. They don't leak outside, so shouldn't be a problem
- toScreen: `isNaN` is redundant since `isFinite(NaN)` is already false. Also unwrap `every` just in case and reuse `pt` vector