### PR TITLE
Feature/offline improvements

### DIFF
--- a/offline/logger.ts
+++ b/offline/logger.ts
@@ -21,7 +21,7 @@ export interface Logger {
      * Log an error message.
      * @param message: The error message to be displayed.
      */
-    error(message: string): void;
+    error(message: OfflineErrorMessage): void;
 
     /**
      * Update progress for potentially long running processes, such as synchronization.
@@ -32,3 +32,30 @@ export interface Logger {
     progress?(value: number, max: number | undefined, operation: "scan" | "download"): void;
 }
 
+/**
+ * Offline error message
+ */
+export interface OfflineErrorMessage {
+    /**
+     * Human readable error message
+     */
+    message: string;
+    /**
+     * Possible error type if it can be provided
+     */
+    id?: OfflineErrorCode;
+}
+
+/**
+ * Offline error code
+ */
+export enum OfflineErrorCode {
+    /**
+     * Device disk drive quota exceeded
+     */
+    quotaExceeded,
+    /**
+     * Device is offline
+     */
+    offline
+}

--- a/offline/opfs/index.ts
+++ b/offline/opfs/index.ts
@@ -300,7 +300,11 @@ class OfflineDirectoryOPFS {
         worker.postMessage(msg, [buffer]);
         const response = await promises.create<WriteResponse>(id);
         if (response.error) {
-            throw new Error(response.error);
+            const error = new Error(response.error);
+            if (response.errorName) {
+                error.name = response.errorName;
+            }
+            throw error;
         }
     }
 
@@ -322,7 +326,11 @@ class OfflineDirectoryOPFS {
         worker.postMessage(openMsg);
         const openResponse = await promises.create<OpenStreamResponse>(openId);
         if (openResponse.error) {
-            throw new Error(openResponse.error);
+            const error = new Error(openResponse.error);
+            if (openResponse.errorName) {
+                error.name = openResponse.errorName;
+            }
+            throw error;
         }
         const reader = stream.getReader();
 

--- a/offline/opfs/index.ts
+++ b/offline/opfs/index.ts
@@ -227,11 +227,20 @@ class OfflineDirectoryOPFS {
                 while (prevIndex < buffer.length) {
                     let index = buffer.indexOf(10, prevIndex);
                     const line = buffer.subarray(prevIndex, index);
-                    const text = decoder.decode(line, { stream: true });
-                    const [name, sizeStr] = text.split(",");
-                    const size = Number.parseInt(sizeStr);
-                    prevIndex = index + 1;
-                    yield { name, size };
+                    try {
+                        const text = decoder.decode(line, { stream: true });
+                        const [name, sizeStr] = text.split(",");
+                        const size = Number.parseInt(sizeStr);
+                        if (Number.isNaN(size)) {
+                            console.warn(`Error reading offline journal: parsed size ${sizeStr} is not a number`);
+                            break;
+                        }
+                        prevIndex = index + 1;
+                        yield { name, size };
+                    } catch (ex) {
+                        console.warn("Error reading offline journal", ex);
+                        break;
+                    }
                 }
             }
         }

--- a/offline/opfs/messages.ts
+++ b/offline/opfs/messages.ts
@@ -154,6 +154,7 @@ export interface WriteResponse {
     readonly kind: "write";
     readonly id: number;
     readonly error?: string;
+    readonly errorName?: string;
 }
 
 /** @internal */
@@ -161,6 +162,7 @@ export interface OpenStreamResponse {
     readonly kind: "open_write_stream";
     readonly id: number;
     readonly error?: string;
+    readonly errorName?: string;
 }
 
 /** @internal */

--- a/offline/opfs/worker/index.ts
+++ b/offline/opfs/worker/index.ts
@@ -176,26 +176,30 @@ async function handleIORequest(data: IORequest): Promise<ResponseMessage> {
         }
         case "write": {
             let error: string | undefined;
+            let errorName: string | undefined;
             try {
                 await writeFile(data.dir, data.file, data.buffer);
             } catch (ex: any) {
                 error = ex.message ?? ex.toString();
+                errorName = ex.name;
                 console.warn(`${data.file}: ${error}`);
             }
-            response = { kind: "write", id: data.id, error } as const satisfies WriteResponse;
+            response = { kind: "write", id: data.id, error, errorName } as const satisfies WriteResponse;
             break;
         }
         case "open_write_stream": {
             let error: string | undefined;
+            let errorName: string | undefined;
             try {
                 const handle = await createFile(data.dir, data.file, data.size);
                 const key = `${data.dir}/${data.file}`;
                 streamHandles.set(key, handle);
             } catch (ex: any) {
                 error = ex.message ?? ex.toString();
+                errorName = ex.name;
                 console.warn(`${data.file}: ${error}`);
             }
-            response = { kind: "open_write_stream", id: data.id, error } as const satisfies OpenStreamResponse;
+            response = { kind: "open_write_stream", id: data.id, error, errorName } as const satisfies OpenStreamResponse;
             break;
         }
         case "append_stream": {

--- a/offline/scene.ts
+++ b/offline/scene.ts
@@ -264,6 +264,10 @@ export class OfflineScene {
                     for (const error of errors) {
                         await downloadFile(error.name, error.size);
                     }
+
+                    if (errorQueue.length > 0) {
+                        throw new Error(`Failed to download ${errorQueue.length} files!`);
+                    }
                 }
             }
             await downloadFiles(onlineManifest.glFiles, "webgl2_bin");
@@ -273,13 +277,13 @@ export class OfflineScene {
 
             logger?.progress?.(totalByteSize, totalByteSize, "download");
 
-            // add manifest.
-            const manifestBuffer = new TextEncoder().encode(JSON.stringify(manifestData)).buffer;
-            await dir.write(manifestName, manifestBuffer); // TODO: use hashed version?
-
             if (errorQueue.length > 0) {
                 throw new Error(`Failed to download ${errorQueue.length} files!`);
             }
+
+            // add manifest.
+            const manifestBuffer = new TextEncoder().encode(JSON.stringify(manifestData)).buffer;
+            await dir.write(manifestName, manifestBuffer); // TODO: use hashed version?
 
             // add index.json to local files last to mark the completion of sync.
             const indexBuffer = new TextEncoder().encode(JSON.stringify(sceneIndex)).buffer;

--- a/offline/scene.ts
+++ b/offline/scene.ts
@@ -221,7 +221,15 @@ export class OfflineScene {
                                     throw error;
                                 }
                                 if (typeof error == "object" && error instanceof Error && error.name === "QuotaExceededError") {
-                                    throw error;
+                                    throw new DOMException();
+                                }
+
+                                // iOS verison of QuotaExceededError. It's more generic, but consider it's quota exceeded here.
+                                // The other possible reason is that the write handle is closed, which is not supposed to be the case
+                                // because truncate happens right after handle creation.
+                                if (typeof error == "object" && error instanceof Error && error.name === "InvalidStateError" &&
+                                    (error.message === "Failed to truncate file" || error.message === "Failed to write to file")) {
+                                    throw new DOMException("Not enough disk space", "QuotaExceededError");
                                 }
                                 
                                 errorQueue.push({ name, size });

--- a/offline/scene.ts
+++ b/offline/scene.ts
@@ -264,10 +264,10 @@ export class OfflineScene {
                     for (const error of errors) {
                         await downloadFile(error.name, error.size);
                     }
+                }
 
-                    if (errorQueue.length > 0) {
-                        throw new Error(`Failed to download ${errorQueue.length} files!`);
-                    }
+                if (errorQueue.length > 0) {
+                    throw new Error(`Failed to download ${errorQueue.length} files!`);
                 }
             }
             await downloadFiles(onlineManifest.glFiles, "webgl2_bin");

--- a/offline/scene.ts
+++ b/offline/scene.ts
@@ -221,15 +221,7 @@ export class OfflineScene {
                                     throw error;
                                 }
                                 if (typeof error == "object" && error instanceof Error && error.name === "QuotaExceededError") {
-                                    throw new DOMException();
-                                }
-
-                                // iOS verison of QuotaExceededError. It's more generic, but consider it's quota exceeded here.
-                                // The other possible reason is that the write handle is closed, which is not supposed to be the case
-                                // because truncate happens right after handle creation.
-                                if (typeof error == "object" && error instanceof Error && error.name === "InvalidStateError" &&
-                                    (error.message === "Failed to truncate file" || error.message === "Failed to write to file")) {
-                                    throw new DOMException("Not enough disk space", "QuotaExceededError");
+                                    throw error;
                                 }
                                 
                                 errorQueue.push({ name, size });

--- a/offline/state.ts
+++ b/offline/state.ts
@@ -56,7 +56,7 @@ class OfflineViewState {
     async addScene(id: string): Promise<OfflineScene | undefined> {
         const { storage, scenes, logger } = this;
         if (scenes.has(id)) {
-            logger?.error("scene already added");
+            logger?.error(errorMessage("scene already added"));
         }
         try {
             logger?.status("adding scene");

--- a/offline/util.ts
+++ b/offline/util.ts
@@ -1,3 +1,4 @@
+import type { OfflineErrorCode, OfflineErrorMessage } from "./logger";
 import { type PathNameFormatter, type PathNameParser, type ResourceType } from "./storage";
 
 /**
@@ -16,10 +17,10 @@ import { type PathNameFormatter, type PathNameParser, type ResourceType } from "
  * @param value The exception
  * @returns Error.message, if "message" exists, value.toString() if not.
  */
-export function errorMessage(value: unknown): string {
+export function errorMessage(value: unknown, id?: OfflineErrorCode): OfflineErrorMessage {
     function isError(value: any): value is Error {
         return value && "message" in value;
     }
-    return isError(value) ? value.message : typeof (value) == "string" ? value : (value as any).toString();
+    const message = isError(value) ? value.message : typeof (value) == "string" ? value : (value as any).toString();
+    return { message, id };
 }
-

--- a/offline/worker/file.ts
+++ b/offline/worker/file.ts
@@ -4,6 +4,14 @@ export async function storeOfflineFileSync(response: Response, dirHandle: FileSy
     const buffer = await response.clone().arrayBuffer();
     const fileHandle = await dirHandle.getFileHandle(filename, { create: true });
     const file = await fileHandle.createSyncAccessHandle();
-    file.write(new Uint8Array(buffer));
-    file.close();
+    try {
+        file.write(new Uint8Array(buffer));
+        file.close();
+    } catch (e: unknown) {
+        if (e instanceof DOMException && e.name === 'QuotaExceededError') {
+            file.close();
+            dirHandle.removeEntry(filename);
+        }
+        throw e;
+    }
 }

--- a/offline/worker/file.ts
+++ b/offline/worker/file.ts
@@ -8,9 +8,11 @@ export async function storeOfflineFileSync(response: Response, dirHandle: FileSy
         file.write(new Uint8Array(buffer));
         file.close();
     } catch (e: unknown) {
-        if (e instanceof DOMException && e.name === 'QuotaExceededError') {
+        try {
             file.close();
             dirHandle.removeEntry(filename);
+        } catch (e2) {
+            console.warn("Error closing/removing file after failed truncation", e2);
         }
         throw e;
     }

--- a/offline/worker/file.ts
+++ b/offline/worker/file.ts
@@ -12,7 +12,7 @@ export async function storeOfflineFileSync(response: Response, dirHandle: FileSy
             file.close();
             dirHandle.removeEntry(filename);
         } catch (e2) {
-            console.warn("Error closing/removing file after failed truncation", e2);
+            console.warn("Error closing/removing file after failed write", e2);
         }
         throw e;
     }


### PR DESCRIPTION
https://trello.com/c/VOTBFW0n/753-offilne-improvements-when-device-is-out-of-disk-space

Some minor improvements for offline:
- When getting `QuotaExceededError` - abort after 5 attempts since there's no point to retry. It doesn't work on Safari since it doesn't use this type of error.
- `error` in logger now contains ID. Currently only `quotaExceeded` and `offline`
- When reading journal - stop reading when getting a bad file entry
- When writing to file (both in full sync and incremental) or opening a stream for a large file: if truncate/write fails - delete the file. Otherwise we have a broken empty file, that's used in rendering later and scene appears corrupted.
- In scene.ts -> `sync`: don't write manifest if there are still errors in the error queue
- In `downloadFiles`: abort when still having errors in the queue by end. Currently we may have a lot of retries:
  1. Get 100 errors
  2. Retry all 100 for 3 times
  3. Go into next `downloadFiles` - there we already have 100 errors, so retry them 3 times again
  4. Same with the next `downloadFiles`
  5. Finally one more `Promise.all` after wards
  6. So there can be up to 10 retries depending on which `downloadFiles` error came from