### PR TITLE
Feature/async id to hash

### DIFF
--- a/measure/worker/util.ts
+++ b/measure/worker/util.ts
@@ -148,11 +148,13 @@ export class Downloader {
 
     async request(
         filename: string,
+        onlineRequestInit?: RequestInit
     ) {
         const url = new URL(filename, this.baseUrl);
         if (!url.search) url.search = this.baseUrl?.search ?? "";
         const request = new Request(url, { mode: "cors" });
-        const response = await requestOfflineFile(request) ?? await fetch(url.toString(), { mode: "cors" });
+        const response = await requestOfflineFile(request) ??
+            await fetch(request, { mode: "cors", ...onlineRequestInit });
         if (!response.ok) {
             throw new Error(`HTTP Error: ${response.status}: ${response.statusText}`);
         }


### PR DESCRIPTION
https://trello.com/c/A2H4Tj52/782-measure-lazy-resolve-id-hash

In measure worker instead of loading entire object ID -> brep mapping on app start:
- Send HEAD request for the file to find it's size and check if it exists
- Then on demand resolve ID -> brep. One request per ID. Requests are small (response is 16 bytes) and fast. Usually we need to resolve it whenever we use measure tools on an object, so upon clicking. Thus there shouldn't be too many requests flying at the same time. Exception is loading a bookmark with many measurements setup, but it's not clear if that might be an issue. Potential improvement of this particular approach is to fetch blocks (say 1000 adjacent IDs at once) instead of single IDs
- In offline mode we have entire file, so using the old approach

Slightly unrelated change:
- When testing - noticed that loading a bookmark - browser can fire many duplicate brep requests, because current app-level cache doesn't handle it nicely. Browser handles this case fine, but just for clarity app-level cache is fixed.