### PR TITLE
Dispose previous root nodes in reloadScene

### DIFF
--- a/core3d/modules/octree/context.ts
+++ b/core3d/modules/octree/context.ts
@@ -149,11 +149,8 @@ export class OctreeModuleContext implements RenderModuleContext, OctreeContext {
                 }
 
                 // delete existing scene
-                for (const rootNode of Object.values(this.rootNodes)) {
-                    rootNode.dispose();
-                }
-                this.rootNodes = {};
-
+                this.disposeRootNodes();
+                
                 // update material atlas if url has changed
                 const url = scene?.url;
                 if (url != this.url) {
@@ -750,6 +747,13 @@ export class OctreeModuleContext implements RenderModuleContext, OctreeContext {
     dispose() {
         this.contextLost();
         this.resources.bin.dispose();
+        this.disposeRootNodes();
+    }
+
+    private disposeRootNodes() {
+        for (const rootNode of Object.values(this.rootNodes)) {
+            rootNode.dispose();
+        }
         this.rootNodes = {};
     }
 
@@ -758,6 +762,7 @@ export class OctreeModuleContext implements RenderModuleContext, OctreeContext {
         await this.loader.abortAllPromise; // make sure we wait for any previous aborts to complete
         const rootNodes = await createSceneRootNodes(this, scene.config, this.renderContext.deviceProfile);
         if (rootNodes) {
+            this.disposeRootNodes();
             this.rootNodes = rootNodes;
         }
         this.suspendUpdates = false;


### PR DESCRIPTION
https://trello.com/c/uSvXmVgv/755-filter-default-highlight-action-leaks-memory

The issue is memory gpu.buffers memory going up when switching between default visibility mode and using "filter" mode as the default one.

Turns out when we switch to/from "filter" visibility - we reload root nodes (calling `reloadScene` in octree/context.ts) and don't clear previous `rootNodes`, so `resourceBins` in core3d/context.ts grow with every switch.

So gpu.buffers number is just wrong, but because we don't clear root nodes - memory profile starts looking like this:
![image](https://github.com/novorender/ts/assets/158474630/2a5be23f-9734-4da2-9299-4fae1f9c8e6c)

JS heap memory is leaking, but very slow, so would likely not be an issue.

With fix it looks like this, but looks like after ~50 visibility mode switches only around 3 MB leaked.
![image](https://github.com/novorender/ts/assets/158474630/0cb4ef86-0980-44f6-bf83-3f16894a7a81)
