### PR TITLE
Deviations visible range

### DIFF
--- a/core3d/common.glsl
+++ b/core3d/common.glsl
@@ -212,6 +212,8 @@ struct SceneUniforms {
     lowp int deviationIndex;
     mediump float deviationFactor;
     mediump vec2 deviationRange;
+    mediump float deviationVisibleRangeStart;
+    mediump float deviationVisibleRangeEnd;
     mediump vec4 deviationUndefinedColor;
     bool useProjectedPosition;
     // terrain elevation

--- a/core3d/modules/octree/context.ts
+++ b/core3d/modules/octree/context.ts
@@ -101,6 +101,8 @@ export class OctreeModuleContext implements RenderModuleContext, OctreeContext {
             values.deviationFactor = deviation.mixFactor;
             values.deviationUndefinedColor = deviation.undefinedColor ?? vec4.fromValues(0, 0, 0, 0);
             values.deviationRange = gradientRange(deviation.colorGradient);
+            values.deviationVisibleRangeStart = deviation.visibleRangeStart ?? Number.MIN_SAFE_INTEGER;
+            values.deviationVisibleRangeEnd = deviation.visibleRangeEnd ?? Number.MAX_SAFE_INTEGER;
             values.useProjectedPosition = points.useProjectedPosition;
             const deviationColors = computeGradientColors(Gradient.size, deviation.colorGradient);
             this.gradientsImage.set(deviationColors, 0 * Gradient.size * 4);

--- a/core3d/modules/octree/module.ts
+++ b/core3d/modules/octree/module.ts
@@ -25,6 +25,8 @@ export class OctreeModule implements RenderModule {
         deviationIndex: "int",
         deviationFactor: "float",
         deviationRange: "vec2",
+        deviationVisibleRangeStart: "float",
+        deviationVisibleRangeEnd: "float",
         deviationUndefinedColor: "vec4",
         useProjectedPosition: "bool",
         elevationRange: "vec2",

--- a/core3d/modules/octree/shaders/render.vert
+++ b/core3d/modules/octree/shaders/render.vert
@@ -63,6 +63,8 @@ void main() {
             if(dot(scene.deviationUndefinedColor, scene.deviationUndefinedColor) != 0.) {
                 color = scene.deviationUndefinedColor;
             }
+        } else if (deviation < scene.deviationVisibleRangeStart || deviation > scene.deviationVisibleRangeEnd) {
+            color = vec4(0, 0, 0, 0);
         } else {
             vec4 gradientColor = getGradientColor(textures.gradients, deviation, deviationV, scene.deviationRange);
             color = mix(vertexColor0, gradientColor, scene.deviationFactor);

--- a/core3d/state/default.ts
+++ b/core3d/state/default.ts
@@ -103,7 +103,9 @@ export function defaultRenderState(): RenderState {
                         { position: 0.5, color: [1, 1, 0, 1] },
                         { position: 1, color: [0, 1, 0, 1] },
                     ],
-                }
+                },
+                visibleRangeStart: Number.MIN_SAFE_INTEGER,
+                visibleRangeEnd: Number.MAX_SAFE_INTEGER
             },
             useProjectedPosition: false
         },

--- a/core3d/state/index.ts
+++ b/core3d/state/index.ts
@@ -429,6 +429,16 @@ export interface RenderStatePointCloud {
          */
         readonly colorGradient: RenderStateColorGradient<RGBA>;
 
+        /** Points with deviation below this value are hidden.
+         * @default Number.MIN_SAFE_INTEGER
+         */
+        readonly visibleRangeStart: number;
+
+        /** Points with deviation above this value are hidden.
+         * @default Number.MAX_SAFE_INTEGER
+         */
+        readonly visibleRangeEnd: number;
+
         /** 
          * The color of undefined points
          */


### PR DESCRIPTION
https://trello.com/c/YLPyRCNq/739-deviations-show-percentages-for-each-color-stop

Add new options for deviations - visibleRangeStart and visibleRangeEnd. If points have deviations outside that range - they get alpha=0 color.