### PR TITLE
Add getObjectsOutlinePlaneBoundingRectInWorld

### DIFF
--- a/web_app/view.ts
+++ b/web_app/view.ts
@@ -9,7 +9,6 @@ import { loadSceneDataOffline, type DataContext } from "data";
 import * as DataAPI from "data/api";
 import { OfflineFileNotFoundError, hasOfflineDir, requestOfflineFile } from "offline/file";
 import { outlineLaser, type OutlineIntersection } from "./outline_inspect";
-import type { AABB2 } from "measure/worker/brep";
 
 /**
  * A view base class for Novorender content.


### PR DESCRIPTION
https://trello.com/c/Ns66jI24/813-fly-to-2d-switches-to-3d

The method is used by Fly To function in cross section view to find bounding rect on the clipping plane of currently selected objects.