### PR TITLE
Disable clipping plane picking

### DIFF
--- a/core3d/modules/clipping/index.ts
+++ b/core3d/modules/clipping/index.ts
@@ -83,7 +83,7 @@ class ClippingModuleContext implements RenderModuleContext {
     }
 
     pick(state: DerivedRenderState) {
-        return this.render(state);
+        // return this.render(state);
     }
 
     contextLost(): void {


### PR DESCRIPTION
Clipping plane picking can't be turned off, which doesn't work with novoweb. No other customer uses plane picking as far as we know