### PR TITLE
Render clipping before octree

### DIFF
--- a/core3d/modules/default.ts
+++ b/core3d/modules/default.ts
@@ -15,11 +15,11 @@ export function createDefaultModules() {
     return [
         new BackgroundModule(),
         new CubeModule(),
+        new ClippingModule(),
         new OctreeModule(),
         new DynamicModule(),
         new ToonModule(),
         new GridModule(),
-        new ClippingModule(),
         new WatermarkModule(),
         new TonemapModule(),
     ];


### PR DESCRIPTION
https://trello.com/c/YDFwFKXk/836-add-hud-icon-for-clipping-plane-to-move-the-clipping-plane-and-to-snap-2d-view-to-it

Why: clipping is rendered over outlines and makes outlines less visible. Also toon outlines look pretty good on top of clipping planes. One issue is that it doesn't work as expected when terrain is rendered as background - terrain is tinted, but not regular geometry. For this we're planning to turn off terrain-as-background when there are clipping planes.