### PR TITLE
Option to disable wheel events when shift is down

### DIFF
--- a/web_app/controller/flight.ts
+++ b/web_app/controller/flight.ts
@@ -24,7 +24,6 @@ export class FlightController extends BaseController {
         rotationalVelocity: 1,
         pickDelay: 200,
         proportionalCameraSpeed: null, // { min: 0.2, max: 1000 }
-        enableShiftModifierOnWheel: false
     }
 
     private _position: ReadonlyVec3 = vec3.create();
@@ -337,7 +336,7 @@ export class FlightController extends BaseController {
     /** Function for getting input modifiers based on how far the 3d objects are from the mouse cursor */
     protected modifiers() {
         const { params, recordedMoveBegin, _position, _fov } = this;
-        const { proportionalCameraSpeed, enableShiftModifierOnWheel } = params;
+        const { proportionalCameraSpeed } = params;
         let scale = 20;
         if (proportionalCameraSpeed && recordedMoveBegin) {
             scale = vec3.dist(_position, recordedMoveBegin) * Math.tan(((Math.PI / 180) * _fov) / 2) * 2;
@@ -345,7 +344,7 @@ export class FlightController extends BaseController {
             if (siceMoveDelay < 400) {  //Delay proportinal speed for better feeling on bad devices
                 scale = Math.min(scale, 60 + (siceMoveDelay * 0.5));
             }
-            let mouseWheelModifier = this.input.hasShift && !enableShiftModifierOnWheel ? 0 : clamp(scale / 3, proportionalCameraSpeed.min, proportionalCameraSpeed.max);
+            let mouseWheelModifier = clamp(scale / 3, proportionalCameraSpeed.min, proportionalCameraSpeed.max);
             const mousePanModifier = clamp(scale, proportionalCameraSpeed.min, proportionalCameraSpeed.max);
             const touchMovementModifier = clamp(scale, proportionalCameraSpeed.min, proportionalCameraSpeed.max);
             const pinchModifier = clamp(scale, proportionalCameraSpeed.min, proportionalCameraSpeed.max);
@@ -354,7 +353,7 @@ export class FlightController extends BaseController {
             }
         }
         return {
-            mouseWheelModifier: this.input.hasShift && !enableShiftModifierOnWheel ? 0 : scale, mousePanModifier: scale, touchMovementModifier: scale, pinchModifier: scale, scale
+            mouseWheelModifier: scale, mousePanModifier: scale, touchMovementModifier: scale, pinchModifier: scale, scale
         }
     }
 
@@ -509,11 +508,6 @@ export interface FlightControllerParams {
      * @defaultValue 200
      */
     pickDelay: number;
-
-    /** Option to enable shift to modify mouse wheel speed.
-    * @defaultValue false
-    */
-    enableShiftModifierOnWheel: boolean;
 
     /** 
      * When set, the controller will sample the distance to the pixel under the mouse cursor,

--- a/web_app/controller/input.ts
+++ b/web_app/controller/input.ts
@@ -40,6 +40,9 @@ export class ControllerInput {
 
     /** Consider mouse started moving after mouse passed this distance. Default is 0 */
     mouseMoveSensitivity = 0;
+    
+    /** Ignore wheel events when shift is pressed. Default is false */
+    disableWheelOnShift = false;
 
     /**
      * @param domElement The HTMLElement to subscribe to input events from.
@@ -215,9 +218,10 @@ export class ControllerInput {
 
     private wheel = async (e: WheelEvent) => {
         const { axes } = this;
+        this.updateModifierKeys(e);
+        if (this.disableWheelOnShift && this.hasShift) return;
         this._zoomX = e.offsetX;
         this._zoomY = e.offsetY;
-        this.updateModifierKeys(e);
         await this.callbacks?.moveBegin?.(e);
         this._mouseWheelLastActive = performance.now();
         axes.mouse_wheel += e.deltaY;


### PR DESCRIPTION
It was earlier done with `enableShiftModifierOnWheel` inside flight control - instead of disabling the event - it zeroed the delta when calculation camera movement. The drawback is that it marked camera as moving which could mess with the web app. Instead now we have `disableWheelOnShift` on input, so the event is just ignored completely when shift is pressed.