### PR TITLE
computeGradientColors uses exact colors for first and last pixel

### DIFF
--- a/core3d/modules/octree/gradient.ts
+++ b/core3d/modules/octree/gradient.ts
@@ -24,19 +24,24 @@ export function computeGradientColors(size: number, gradient: RenderStateColorGr
         }
         const color = getColor(0);
         for (let i = 0; i < size; i++) {
-            const texel = (i + 0.5) / size * (maxValue - minValue) + minValue;
-            for (let j = prevIndex; j < n - 1; j++) {
-                prevIndex = j;
-                const e0 = knots[j].position;
-                const e1 = knots[j + 1].position;
-                const c0 = getColor(j);
-                const c1 = getColor(j + 1);
-                if (texel >= e0 && texel < e1) {
-                    const t = (texel - e0) / (e1 - e0);
-                    vec4.lerp(color, c0, c1, t);
-                    break;
+            if (i === size - 1) {
+                vec4.copy(color, getColor(n - 1));
+            } else if (i !== 0) {
+                const texel = (i + 0.5) / size * (maxValue - minValue) + minValue;
+                for (let j = prevIndex; j < n - 1; j++) {
+                    prevIndex = j;
+                    const e0 = knots[j].position;
+                    const e1 = knots[j + 1].position;
+                    const c0 = getColor(j);
+                    const c1 = getColor(j + 1);
+                    if (texel >= e0 && texel < e1) {
+                        const t = (texel - e0) / (e1 - e0);
+                        vec4.lerp(color, c0, c1, t);
+                        break;
+                    }
                 }
             }
+
             const [r, g, b, a] = color;
             pixels[i * 4 + 0] = r * 255;
             pixels[i * 4 + 1] = g * 255;


### PR DESCRIPTION
This is needed for deviation distribution feature where we can show selected range. We use [0,0,0,0] colors immediately outside range to hide other points, but current implementation interpolates these colors so they end up being not exactly [0,0,0,0]

https://trello.com/c/YLPyRCNq/739-deviations-show-percentages-for-each-color-stop