### PR TITLE
In View.loadScene use applyChanges instead of modifyRenderState when setting scene

### DIFF
--- a/web_app/view.ts
+++ b/web_app/view.ts
@@ -384,7 +384,7 @@ export class View<
             const scene = await downloadScene(baseSceneUrl, render.webgl2, abortSignal);
             const stateChanges = { scene };
             flipState(stateChanges, "GLToCAD");
-            this.modifyRenderState(stateChanges);
+            this.applyChanges(stateChanges);
 
             const measureView = await createMeasureView(this._drawContext2d, this.imports);
             await measureView.loadScene(baseSceneUrl, measure ? measure.brepLut : ""); // TODO: include abort signal!


### PR DESCRIPTION
Otherwise scene is not set until changes are actually applied inside run and if client relies on scene - it gets a bit harder to figure out when it's actually available

https://trello.com/c/AmCwkokZ/892-deviations-are-sometimes-not-initialized-because-base-url-is-not-yet-initialized-race-with-view