### PR TITLE
Fix CAD->GL flip issue in loadScene.

### DIFF
--- a/web_app/view.ts
+++ b/web_app/view.ts
@@ -384,7 +384,7 @@ export class View<
             const scene = await downloadScene(baseSceneUrl, render.webgl2, abortSignal);
             const stateChanges = { scene };
             flipState(stateChanges, "GLToCAD");
-            this.applyChanges(stateChanges);
+            this.applyChanges(mergeRecursive({}, stateChanges));
 
             const measureView = await createMeasureView(this._drawContext2d, this.imports);
             await measureView.loadScene(baseSceneUrl, measure ? measure.brepLut : ""); // TODO: include abort signal!


### PR DESCRIPTION
In loadScene we now pass scene to applyChanges.
applyChanges unlike modifyStateChanges flips CAD->GL in place, so we end up returning data in GL space instead of CAD as we did before. Solution is to make a copy before passing to applyChanges.

https://trello.com/c/vsEzNXOb/912-load-scene-unexpected-coordinate-flip