### PR TITLE
Add directions (angles) to labels in getHorizontalDrawItem

### DIFF
--- a/measure/modules/draw/index.ts
+++ b/measure/modules/draw/index.ts
@@ -103,9 +103,13 @@ export interface DrawPart {
     readonly voids?: DrawVoid[];
     /** World coordinates*/
     readonly vertices3D: ReadonlyVec3[];
+    /** Direction of the points. Used for text rotation */
+    readonly directions3D?: ReadonlyVec3[];
 
     /** View space coordinates, in pixel values, empty if the entire part is out of view*/
     vertices2D?: ReadonlyVec2[];
+    /** Angles in 2D space. Angle will be defined only if directions3D is present */
+    angles2D?: number[];
 
     /** Indices reffering to vertices3D and text if it is a list, -1 means an added empty text*/
     indicesOnScreen?: number[];

--- a/measure/modules/road/index.ts
+++ b/measure/modules/road/index.ts
@@ -67,6 +67,7 @@ export interface StationSegmentDrawObject {
 
 export interface StationsDrawObject {
     stationInfo: DrawPart;
+    stationInfoProfiles: number[];
     stationLines: DrawPart[];
     stationMinorLines: DrawPart[];
 }

--- a/measure/modules/road/index.ts
+++ b/measure/modules/road/index.ts
@@ -68,4 +68,5 @@ export interface StationSegmentDrawObject {
 export interface StationsDrawObject {
     stationInfo: DrawPart;
     stationLines: DrawPart[];
+    stationMinorLines: DrawPart[];
 }

--- a/measure/modules/road/module.ts
+++ b/measure/modules/road/module.ts
@@ -135,7 +135,7 @@ export class RoadModule extends BaseModule {
     }
 
     getStationsDrawObject(alignment: Alignment, interval: number, start?: number, elevation?: boolean, slopes?: boolean): StationsDrawObject {
-        const show_station_above = 1;
+        const show_station_above = 0.01;
         const minorTickFreq = 5;
         const minorTickInterval = interval / minorTickFreq;
 
@@ -177,8 +177,8 @@ export class RoadModule extends BaseModule {
                     stationInfo += ", z=" + stationPosition[2].toFixed(2);
                 } if (slopes) {
                     const info = infoBetweenStations(alignment, nextParam - interval, nextParam, true);
-                    if (info?.slope && Math.abs(info?.slope) > show_station_above) {
-                        stationInfo += ", S " + info.slope.toFixed(0) + "%"
+                    if (info?.slope && Math.abs(info.slope) > show_station_above) {
+                        stationInfo += ", S " + (info.slope * 100).toFixed(0) + "%"
                     }
                 }
                 stations.push({ position: stationPosition, direction: vec3.negate(vec3.create(), side), stationInfo });

--- a/measure/modules/road/module.ts
+++ b/measure/modules/road/module.ts
@@ -138,7 +138,7 @@ export class RoadModule extends BaseModule {
         const show_station_above = 1;
         const stationLines: DrawPart[] = [];
         let nextParam = start ?? Math.ceil(alignment.stations[0] / interval) * interval;
-        const stations: { position: ReadonlyVec3, stationInfo: string }[] = [];
+        const stations: { position: ReadonlyVec3, direction: ReadonlyVec3, stationInfo: string }[] = [];
         for (let i = 1; i < alignment.stations.length;) {
             const stationEnd = alignment.stations[i];
             if (stationEnd < nextParam) {
@@ -169,12 +169,12 @@ export class RoadModule extends BaseModule {
                     stationInfo += ", S " + info.slope.toFixed(0) + "%"
                 }
             }
-            stations.push({ position: lineVertices[1], stationInfo });
+            stations.push({ position: lineVertices[1], direction: vec3.negate(vec3.create(), side), stationInfo });
             nextParam += interval;
         }
         return {
             stationLines,
-            stationInfo: { drawType: "text", vertices3D: stations.map(s => s.position), text: [stations.map(s => s.stationInfo)] }
+            stationInfo: { drawType: "text", vertices3D: stations.map(s => s.position), directions3D: stations.map(s => s.direction), text: [stations.map(s => s.stationInfo)] },
         };
     }
 

--- a/measure/modules/road/module.ts
+++ b/measure/modules/road/module.ts
@@ -169,7 +169,7 @@ export class RoadModule extends BaseModule {
                     stationInfo += ", S " + info.slope.toFixed(0) + "%"
                 }
             }
-            stations.push({ position: lineVertices[1], direction: vec3.negate(vec3.create(), side), stationInfo });
+            stations.push({ position: stationPosition, direction: vec3.negate(vec3.create(), side), stationInfo });
             nextParam += interval;
         }
         return {

--- a/measure/modules/road/module.ts
+++ b/measure/modules/road/module.ts
@@ -143,7 +143,6 @@ export class RoadModule extends BaseModule {
         const stationMinorLines: DrawPart[] = [];
 
         let nextParam = start ?? Math.ceil(alignment.stations[0] / minorTickInterval) * minorTickInterval;
-        let stationsProcessed = 0;
         const stations: { position: ReadonlyVec3, direction: ReadonlyVec3, stationInfo: string }[] = [];
 
         for (let i = 1; i < alignment.stations.length;) {
@@ -152,7 +151,7 @@ export class RoadModule extends BaseModule {
                 ++i;
                 continue;
             }
-            const isMinorTick = stationsProcessed % minorTickFreq !== 0;
+            const isMinorTick = nextParam % interval !== 0;
             const stationStart = alignment.stations[i - 1];
             const dir = vec3.sub(vec3.create(), alignment.points[i], alignment.points[i - 1]);
             vec3.normalize(dir, dir);
@@ -186,7 +185,6 @@ export class RoadModule extends BaseModule {
             }
 
             nextParam += minorTickInterval;
-            stationsProcessed += 1;
         }
         return {
             stationLines,

--- a/measure/modules/road/module.ts
+++ b/measure/modules/road/module.ts
@@ -143,7 +143,7 @@ export class RoadModule extends BaseModule {
         const stationMinorLines: DrawPart[] = [];
 
         let nextParam = start ?? Math.ceil(alignment.stations[0] / minorTickInterval) * minorTickInterval;
-        const stations: { position: ReadonlyVec3, direction: ReadonlyVec3, stationInfo: string }[] = [];
+        const stations: { position: ReadonlyVec3, direction: ReadonlyVec3, stationInfo: string, param: number }[] = [];
 
         for (let i = 1; i < alignment.stations.length;) {
             const stationEnd = alignment.stations[i];
@@ -181,7 +181,7 @@ export class RoadModule extends BaseModule {
                         stationInfo += ", S " + (info.slope * 100).toFixed(0) + "%"
                     }
                 }
-                stations.push({ position: stationPosition, direction: vec3.negate(vec3.create(), side), stationInfo });
+                stations.push({ position: stationPosition, direction: vec3.negate(vec3.create(), side), stationInfo, param: nextParam });
             }
 
             nextParam += minorTickInterval;
@@ -190,6 +190,7 @@ export class RoadModule extends BaseModule {
             stationLines,
             stationMinorLines,
             stationInfo: { drawType: "text", vertices3D: stations.map(s => s.position), directions3D: stations.map(s => s.direction), text: [stations.map(s => s.stationInfo)] },
+            stationInfoProfiles: stations.map(s => s.param)
         };
     }
 


### PR DESCRIPTION
Extend `DrawPart` with optional `directions3D` and `angles2D` to be able to set angles for labels.

Angle could be done before by having two vertices per text, but there are issues:

1. Need draw part per text, which is not compatible with current single draw part text array, so we won't be able to use `indicesOnScreen` and zoom dependent label skipping
2. Length of the line can be tricky to set - it has to be long enough for label to not be hidden, but also if points are outside the screen - it may cause issues

https://trello.com/c/YVfSd7aA/931-horizontal-alignment-widget